### PR TITLE
docs: updated typo on query reference naming

### DIFF
--- a/docs/firestore/query.mdx
+++ b/docs/firestore/query.mdx
@@ -26,15 +26,15 @@ function Products() {
   const products = query(collection(firestore, "products"), limit(limitTo));
 
   // Provide the query to the hook
-  const ref = useFirestoreQuery(["products", { limitTo }], products, {
+  const products = useFirestoreQuery(["products", { limitTo }], products, {
     subscribe: true,
   });
 
-  if (ref.isLoading) {
+  if (products.isLoading) {
     return <div>Loading...</div>;
   }
 
-  const snapshot: QuerySnapshot<DocumentData> = ref.data;
+  const snapshot: QuerySnapshot<DocumentData> = products.data;
 
   return snapshot.docs.map((docSnapshot) => {
     const data = docSnapshot.data();

--- a/docs/firestore/query.mdx
+++ b/docs/firestore/query.mdx
@@ -26,15 +26,15 @@ function Products() {
   const products = query(collection(firestore, "products"), limit(limitTo));
 
   // Provide the query to the hook
-  const query = useFirestoreQuery(["products", { limitTo }], products, {
+  const ref = useFirestoreQuery(["products", { limitTo }], products, {
     subscribe: true,
   });
 
-  if (query.isLoading) {
+  if (ref.isLoading) {
     return <div>Loading...</div>;
   }
 
-  const snapshot: QuerySnapshot<DocumentData> = query.data;
+  const snapshot: QuerySnapshot<DocumentData> = ref.data;
 
   return snapshot.docs.map((docSnapshot) => {
     const data = docSnapshot.data();


### PR DESCRIPTION
```js
const query = useFirestoreQuery(["products", { limitTo }], products, {
    subscribe: true,
  });
```

`query` conflicts with imported query naming, updated to `ref`