### PR TITLE
feat(firestore): support idField args

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,13 @@
     "es2021": true,
     "node": true
   },
-  "extends": ["plugin:react/recommended", "google"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:react/recommended",
+    "google",
+    "plugin:@typescript-eslint/eslint-recommended",
+    "plugin:@typescript-eslint/recommended"
+  ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "ecmaFeatures": {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,6 +26,9 @@
   },
   "plugins": ["react", "@typescript-eslint"],
   "rules": {
+    "@typescript-eslint/ban-ts-comment": "off",
+    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-non-null-assertion": "off",
     "quote-props": 0,
     "object-curly-spacing": ["error", "always"],
     "operator-linebreak": "off",

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "typescript": "^4.4.3"
   },
   "scripts": {
-    "test": "firebase emulators:exec --project test-project 'jest'",
-    "test:ci": "firebase emulators:exec --project test-project 'sleep 5 && jest --coverage && codecov'",
+    "test": "firebase emulators:exec --project test-project 'jest --runInBand'",
+    "test:ci": "firebase emulators:exec --project test-project 'sleep 5 && jest --runInBand --coverage && codecov'",
     "lint": "eslint \"**/*.{js,ts,tsx,jsx}\"",
     "lint:fix": "eslint \"**/*.{js,ts,tsx,jsx}\" --fix",
     "emulators": "firebase emulators:exec --project test-project"

--- a/packages/firestore/__test__/helpers.tsx
+++ b/packages/firestore/__test__/helpers.tsx
@@ -25,7 +25,7 @@ setLogger({
   log: console.log,
   warn: console.warn,
   // ✅ no more errors on the console
-  error: () => {},
+  error: () => null,
 });
 
 let emulatorsStarted = false;
@@ -38,7 +38,7 @@ export function genInt(): number {
   return Math.floor(Math.random() * (5000 - 1 + 1) + 1);
 }
 
-export function init() {
+export function init(): any {
   const firebase = initializeApp({
     projectId: "test-project",
   });
@@ -67,7 +67,7 @@ export function init() {
   return { client, wrapper, firebase, firestore };
 }
 
-export async function wipe() {
+export async function wipe(): Promise<void> {
   await axios(
     "http://localhost:8080/emulator/v1/projects/test-project/databases/(default)/documents",
     {

--- a/packages/firestore/__test__/useFirestoreDocument.test.ts
+++ b/packages/firestore/__test__/useFirestoreDocument.test.ts
@@ -313,5 +313,26 @@ describe("useFirestoreDocument", () => {
       expect(result.current.data).toBeDefined();
       expect(result.current.data).toEqual({ baz: "ben" });
     });
+
+    test("it provides the id key", async () => {
+      const hookId = genId();
+      const id = genId();
+      const ref = doc(firestore, genId(), id);
+
+      await setDoc(ref, { foo: "bar" });
+
+      const { result, waitFor } = renderHook(
+        () =>
+          useFirestoreDocumentData<"id">(hookId, ref, {
+            idField: "id",
+          }),
+        { wrapper }
+      );
+
+      await waitFor(() => result.current.isSuccess, { timeout: 5000 });
+
+      expect(result.current.data).toBeDefined();
+      expect(result.current.data).toEqual({ baz: "ben", id });
+    });
   });
 });

--- a/packages/firestore/__test__/useFirestoreDocument.test.ts
+++ b/packages/firestore/__test__/useFirestoreDocument.test.ts
@@ -332,7 +332,7 @@ describe("useFirestoreDocument", () => {
       await waitFor(() => result.current.isSuccess, { timeout: 5000 });
 
       expect(result.current.data).toBeDefined();
-      expect(result.current.data).toEqual({ baz: "ben", id });
+      expect(result.current.data).toEqual({ foo: "bar", id });
     });
   });
 });

--- a/packages/firestore/__test__/useFirestoreQuery.test.ts
+++ b/packages/firestore/__test__/useFirestoreQuery.test.ts
@@ -373,9 +373,8 @@ describe("useFirestoreQuery", () => {
 
       await waitFor(() => result.current.isSuccess, { timeout: 5000 });
 
-      expect(result.current.data).toEqual(
-        expect.arrayContaining([{ foo: "bar", id }])
-      );
+      expect(result.current.data[0].foo).toEqual("bar");
+      expect(typeof result.current.data[0].id).toBe("string");
     });
   });
 
@@ -496,7 +495,7 @@ describe("useFirestoreQuery", () => {
         addDoc(ref, { foo: 5 }),
       ]);
 
-      const q = query(ref, limit(2));
+      const q = query(ref, limit(2), orderBy("foo"));
 
       const mock = jest.fn();
       const { result, waitFor } = renderHook(
@@ -599,11 +598,10 @@ describe("useFirestoreQuery", () => {
       await waitFor(() => result.current.isSuccess, { timeout: 5000 });
 
       expect(result.current.data.pages[0].length).toBe(2);
-      expect(result.current.data.pages[0]).toEqual([{ foo: 1 }, { foo: 2 }]);
       expect(result.current.data.pages[0][0].foo).toEqual(1);
-      expect(result.current.data.pages[0][0].id).toBeInstanceOf(String);
+      expect(typeof result.current.data.pages[0][0].id).toBe("string");
       expect(result.current.data.pages[0][1].foo).toEqual(2);
-      expect(result.current.data.pages[0][1].id).toBeInstanceOf(String);
+      expect(typeof result.current.data.pages[0][1].id).toBe("string");
 
       await act(async () => {
         await result.current.fetchNextPage();
@@ -614,9 +612,9 @@ describe("useFirestoreQuery", () => {
       expect(result.current.data.pages.length).toBe(2);
       expect(result.current.data.pages[1].length).toBe(2);
       expect(result.current.data.pages[1][0].foo).toEqual(3);
-      expect(result.current.data.pages[1][0].id).toBeInstanceOf(String);
+      expect(typeof result.current.data.pages[1][0].id).toBe("string");
       expect(result.current.data.pages[1][1].foo).toEqual(4);
-      expect(result.current.data.pages[1][1].id).toBeInstanceOf(String);
+      expect(typeof result.current.data.pages[1][1].id).toBe("string");
     });
   });
 });

--- a/packages/firestore/src/index.ts
+++ b/packages/firestore/src/index.ts
@@ -31,6 +31,10 @@ export type UseFirestoreHookOptions =
       subscribe?: false;
     } & GetSnapshotOptions);
 
+export type WithIdField<D, F = void> = F extends string
+  ? D & { [key in F]: string }
+  : D;
+
 export * from "./useFirestoreDocument";
 export * from "./useFirestoreQuery";
 export * from "./useFirestoreMutation";

--- a/packages/firestore/src/useFirestoreMutation.ts
+++ b/packages/firestore/src/useFirestoreMutation.ts
@@ -29,7 +29,11 @@ import {
   WithFieldValue,
   WriteBatch,
 } from "firebase/firestore";
-import { useMutation, UseMutationOptions } from "react-query";
+import {
+  useMutation,
+  UseMutationOptions,
+  UseMutationResult,
+} from "react-query";
 
 export function useFirestoreCollectionMutation<T = DocumentData>(
   ref: CollectionReference<T>,
@@ -38,7 +42,7 @@ export function useFirestoreCollectionMutation<T = DocumentData>(
     Error,
     WithFieldValue<T>
   >
-) {
+): UseMutationResult<DocumentReference<T>, Error, WithFieldValue<T>> {
   return useMutation<DocumentReference<T>, Error, WithFieldValue<T>>((data) => {
     return addDoc<T>(ref, data);
   }, useMutationOptions);
@@ -48,9 +52,9 @@ export function useFirestoreDocumentMutation<T = DocumentData>(
   ref: DocumentReference<T>,
   options?: SetOptions,
   useMutationOptions?: UseMutationOptions<void, Error, WithFieldValue<T>>
-) {
+): UseMutationResult<void, Error, WithFieldValue<T>> {
   return useMutation<void, Error, WithFieldValue<T>>((data) => {
-    if (!!options) {
+    if (options) {
       return setDoc<T>(ref, data, options);
     }
 
@@ -61,7 +65,7 @@ export function useFirestoreDocumentMutation<T = DocumentData>(
 export function useFirestoreDocumentDeletion(
   ref: DocumentReference,
   useMutationOptions?: UseMutationOptions<void, Error, void>
-) {
+): UseMutationResult<void, Error, void> {
   return useMutation<void, Error, void>(
     () => deleteDoc(ref),
     useMutationOptions
@@ -72,7 +76,7 @@ export function useFirestoreTransaction<T = void>(
   firestore: Firestore,
   updateFunction: (tsx: Transaction) => Promise<T>,
   useMutationOptions?: UseMutationOptions<T, Error, void>
-) {
+): UseMutationResult<T, Error, void> {
   return useMutation<T, Error, void>(() => {
     return runTransaction<T>(firestore, updateFunction);
   }, useMutationOptions);
@@ -81,7 +85,7 @@ export function useFirestoreTransaction<T = void>(
 export function useFirestoreWriteBatch(
   batch: WriteBatch,
   useMutationOptions?: UseMutationOptions<void, Error, void>
-) {
+): UseMutationResult<void, Error, void> {
   return useMutation<void, Error, void>(() => {
     return batch.commit();
   }, useMutationOptions);

--- a/packages/firestore/src/useFirestoreQuery.ts
+++ b/packages/firestore/src/useFirestoreQuery.ts
@@ -267,7 +267,10 @@ export function useFirestoreQueryData<
   });
 }
 
-export function useFirestoreInfiniteQuery<T = DocumentData, R = T[]>(
+export function useFirestoreInfiniteQuery<
+  T = DocumentData,
+  R = QuerySnapshot<T>
+>(
   key: QueryKey,
   initialQuery: Query<T>,
   getNextQuery: (snapshot: QuerySnapshot<T>) => Query<T> | undefined,

--- a/packages/firestore/src/useFirestoreQuery.ts
+++ b/packages/firestore/src/useFirestoreQuery.ts
@@ -24,6 +24,8 @@ import {
   useInfiniteQuery,
   QueryFunctionContext,
   UseInfiniteQueryOptions,
+  UseQueryResult,
+  UseInfiniteQueryResult,
 } from "react-query";
 import {
   getDocs,
@@ -38,7 +40,11 @@ import {
   Firestore,
   SnapshotOptions,
 } from "firebase/firestore";
-import { GetSnapshotSource, UseFirestoreHookOptions } from "./index";
+import {
+  GetSnapshotSource,
+  UseFirestoreHookOptions,
+  WithIdField,
+} from "./index";
 
 const namedQueryCache: { [key: string]: Query } = {};
 
@@ -112,7 +118,7 @@ export function useFirestoreQuery<T = DocumentData, R = QuerySnapshot<T>>(
   query: QueryType<T>,
   options?: UseFirestoreHookOptions,
   useQueryOptions?: Omit<UseQueryOptions<QuerySnapshot<T>, Error, R>, "queryFn">
-) {
+): UseQueryResult<R, Error> {
   const client = useQueryClient();
   const unsubscribe = useRef<Unsubscribe>();
 
@@ -155,12 +161,40 @@ export function useFirestoreQuery<T = DocumentData, R = QuerySnapshot<T>>(
   });
 }
 
-export function useFirestoreQueryData<T = DocumentData, R = T[]>(
+export function useFirestoreQueryData<T = DocumentData, R = WithIdField<T>[]>(
   key: QueryKey,
   query: QueryType<T>,
   options?: UseFirestoreHookOptions & SnapshotOptions,
-  useQueryOptions?: Omit<UseQueryOptions<T[], Error, R>, "queryFn">
-) {
+  useQueryOptions?: Omit<UseQueryOptions<WithIdField<T>[], Error, R>, "queryFn">
+): UseQueryResult<R, Error>;
+
+export function useFirestoreQueryData<
+  ID extends string,
+  T = DocumentData,
+  R = WithIdField<T, ID>[]
+>(
+  key: QueryKey,
+  query: QueryType<T>,
+  options?: UseFirestoreHookOptions & SnapshotOptions & { idField: ID },
+  useQueryOptions?: Omit<
+    UseQueryOptions<WithIdField<T, ID>[], Error, R>,
+    "queryFn"
+  >
+): UseQueryResult<R, Error>;
+
+export function useFirestoreQueryData<
+  ID extends string,
+  T = DocumentData,
+  R = WithIdField<T, ID>[]
+>(
+  key: QueryKey,
+  query: QueryType<T>,
+  options?: UseFirestoreHookOptions & SnapshotOptions & { idField?: ID },
+  useQueryOptions?: Omit<
+    UseQueryOptions<WithIdField<T, ID>[], Error, R>,
+    "queryFn"
+  >
+): UseQueryResult<R, Error> {
   const client = useQueryClient();
   const unsubscribe = useRef<Unsubscribe>();
 
@@ -168,10 +202,10 @@ export function useFirestoreQueryData<T = DocumentData, R = T[]>(
     return () => unsubscribe.current?.();
   }, []);
 
-  return useQuery<T[], Error, R>({
+  return useQuery<WithIdField<T, ID>[], Error, R>({
     ...useQueryOptions,
     queryKey: useQueryOptions?.queryKey ?? key,
-    async queryFn() {
+    async queryFn(): Promise<WithIdField<T, ID>[]> {
       unsubscribe.current?.();
 
       const _query = await resolveQuery(query);
@@ -179,40 +213,51 @@ export function useFirestoreQueryData<T = DocumentData, R = T[]>(
       if (!options?.subscribe) {
         const snapshot = await getSnapshot(_query, options?.source);
 
-        return snapshot.docs.map((doc) =>
-          doc.data({
+        return snapshot.docs.map((doc) => {
+          let data = doc.data({
             serverTimestamps: options?.serverTimestamps,
-          })
-        );
+          });
+
+          if (options?.idField) {
+            data = {
+              ...data,
+              [options.idField]: doc.id,
+            };
+          }
+
+          return data as WithIdField<T, ID>;
+        });
       }
 
       let resolved = false;
 
-      return new Promise<T[]>((resolve, reject) => {
+      return new Promise<WithIdField<T, ID>[]>((resolve, reject) => {
         unsubscribe.current = onSnapshot(
           _query,
           {
             includeMetadataChanges: options?.includeMetadataChanges,
           },
           (snapshot) => {
+            const docs = snapshot.docs.map((doc) => {
+              let data = doc.data({
+                serverTimestamps: options?.serverTimestamps,
+              });
+
+              if (options?.idField) {
+                data = {
+                  ...data,
+                  [options.idField]: doc.id,
+                };
+              }
+
+              return data as WithIdField<T, ID>;
+            });
+
             if (!resolved) {
               resolved = true;
-              return resolve(
-                snapshot.docs.map((doc) =>
-                  doc.data({
-                    serverTimestamps: options?.serverTimestamps,
-                  })
-                )
-              );
+              return resolve(docs);
             } else {
-              client.setQueryData<T[]>(
-                key,
-                snapshot.docs.map((doc) =>
-                  doc.data({
-                    serverTimestamps: options?.serverTimestamps,
-                  })
-                )
-              );
+              client.setQueryData<WithIdField<T, ID>[]>(key, docs);
             }
           },
           reject
@@ -222,7 +267,7 @@ export function useFirestoreQueryData<T = DocumentData, R = T[]>(
   });
 }
 
-export function useFirestoreInfiniteQuery<T = DocumentData, R = T>(
+export function useFirestoreInfiniteQuery<T = DocumentData, R = T[]>(
   key: QueryKey,
   initialQuery: Query<T>,
   getNextQuery: (snapshot: QuerySnapshot<T>) => Query<T> | undefined,
@@ -233,7 +278,7 @@ export function useFirestoreInfiniteQuery<T = DocumentData, R = T>(
     UseInfiniteQueryOptions,
     "queryFn" | "getNextPageParam"
   >
-) {
+): UseInfiniteQueryResult<R, Error> {
   return useInfiniteQuery<QuerySnapshot<T>, Error, R>({
     queryKey: useInfiniteQueryOptions?.queryKey ?? key,
     async queryFn(ctx: QueryFunctionContext<QueryKey, Query<T>>) {
@@ -246,7 +291,10 @@ export function useFirestoreInfiniteQuery<T = DocumentData, R = T>(
   });
 }
 
-export function useFirestoreInfiniteQueryData<T = DocumentData, R = T>(
+export function useFirestoreInfiniteQueryData<
+  T = DocumentData,
+  R = WithIdField<T>[]
+>(
   key: QueryKey,
   initialQuery: Query<T>,
   getNextQuery: (data: T[]) => Query<T> | undefined,
@@ -254,18 +302,64 @@ export function useFirestoreInfiniteQueryData<T = DocumentData, R = T>(
     source?: GetSnapshotSource;
   } & SnapshotOptions,
   useInfiniteQueryOptions?: Omit<
-    UseInfiniteQueryOptions,
+    UseInfiniteQueryOptions<WithIdField<T>[], Error, R>,
     "queryFn" | "getNextPageParam"
   >
-) {
-  return useInfiniteQuery<T[], Error, R>({
+): UseInfiniteQueryResult<R, Error>;
+
+export function useFirestoreInfiniteQueryData<
+  ID extends string,
+  T = DocumentData,
+  R = WithIdField<T, ID>[]
+>(
+  key: QueryKey,
+  initialQuery: Query<T>,
+  getNextQuery: (data: T[]) => Query<T> | undefined,
+  options?: {
+    source?: GetSnapshotSource;
+  } & SnapshotOptions & { idField: ID },
+  useInfiniteQueryOptions?: Omit<
+    UseInfiniteQueryOptions<WithIdField<T, ID>[], Error, R>,
+    "queryFn" | "getNextPageParam"
+  >
+): UseInfiniteQueryResult<R, Error>;
+
+export function useFirestoreInfiniteQueryData<
+  ID extends string,
+  T = DocumentData,
+  R = WithIdField<T, ID>[]
+>(
+  key: QueryKey,
+  initialQuery: Query<T>,
+  getNextQuery: (data: T[]) => Query<T> | undefined,
+  options?: {
+    source?: GetSnapshotSource;
+  } & SnapshotOptions & { idField?: ID },
+  useInfiniteQueryOptions?: Omit<
+    UseInfiniteQueryOptions<WithIdField<T, ID>[], Error, R>,
+    "queryFn" | "getNextPageParam"
+  >
+): UseInfiniteQueryResult<R, Error> {
+  return useInfiniteQuery<WithIdField<T, ID>[], Error, R>({
     queryKey: useInfiniteQueryOptions?.queryKey ?? key,
-    async queryFn(ctx: QueryFunctionContext<QueryKey, Query<T>>) {
+    async queryFn(
+      ctx: QueryFunctionContext<QueryKey, Query<T>>
+    ): Promise<WithIdField<T, ID>[]> {
       const query: Query<T> = ctx.pageParam ?? initialQuery;
       const snapshot = await getSnapshot(query, options?.source);
-      return snapshot.docs.map((d) =>
-        d.data({ serverTimestamps: options?.serverTimestamps })
-      );
+
+      return snapshot.docs.map((doc) => {
+        let data = doc.data({ serverTimestamps: options?.serverTimestamps });
+
+        if (options?.idField) {
+          data = {
+            ...data,
+            [options.idField]: doc.id,
+          };
+        }
+
+        return data as WithIdField<T, ID>;
+      });
     },
     getNextPageParam(data) {
       return getNextQuery(data);


### PR DESCRIPTION
Allows the support of providing a document id:

```js
useFirestoreDocumentData('', ref, {
  idField: 'id',
});

useFirestoreQueryData('', ref, {
  idField: 'id',
});
```

TypeScript also supported:

```ts
useFirestoreDocumentData<'id'>('', ref, {
  idField: 'id',
});

useFirestoreQueryData<'id'>('', ref, {
  idField: 'id',
});
```