### PR TITLE
Sync peer deps with react-query

### DIFF
--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -21,7 +21,7 @@
   "license": "Apache-2.0",
   "peerDependencies": {
     "firebase": "^9.0.1",
-    "react": "^17.0.2",
+    "react": "^16.8.0 || ^17.0.0",
     "react-query": "^3.23.2"
   }
 }

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -32,7 +32,7 @@
   "license": "Apache-2.0",
   "peerDependencies": {
     "firebase": "^9.0.1",
-    "react": "^17.0.2",
+    "react": "^16.8.0 || ^17.0.0",
     "react-query": "^3.23.2"
   }
 }

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -32,7 +32,7 @@
   "license": "Apache-2.0",
   "peerDependencies": {
     "firebase": "^9.0.1",
-    "react": "^17.0.2",
+    "react": "^16.8.0 || ^17.0.0",
     "react-query": "^3.23.2"
   }
 }

--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -40,7 +40,7 @@
   "license": "Apache-2.0",
   "peerDependencies": {
     "firebase": "^9.0.1",
-    "react": "^17.0.2",
+    "react": "^16.8.0 || ^17.0.0",
     "react-query": "^3.23.2"
   }
 }

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -33,7 +33,7 @@
   "license": "Apache-2.0",
   "peerDependencies": {
     "firebase": "^9.0.1",
-    "react": "^17.0.2",
+    "react": "^16.8.0 || ^17.0.0",
     "react-query": "^3.23.2"
   }
 }


### PR DESCRIPTION
Sync peer deps with react-query. 

Now we can use React ^16.8 as well.