### PR TITLE
Add nav link to missing auth section

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -21,6 +21,7 @@
       "Authentication",
       [
         ["Getting Started", "/auth"],
+        ["Authentication State", "/auth/auth-state"],
         ["ID Token", "/auth/id-token"],
         ["Auth Actions", "/auth/actions"]
       ]


### PR DESCRIPTION
The "Authentication State" section was missing from the docs navigation sidebar, so I've added it there.