### PR TITLE
Let react-query manage observer count

### DIFF
--- a/packages/utils/src/useSubscription.ts
+++ b/packages/utils/src/useSubscription.ts
@@ -112,16 +112,14 @@ export function useSubscription<TData, TError, R = TData>(
     if (!subscribedToQueryCache) {
       const queryCache = queryClient.getQueryCache();
       queryCacheUnsubscribes[subscriptionHash] = queryCache.subscribe((event) => {
-        if (!event) {
+        if (!event || event.query.queryHash !== hashFn(queryKey)) {
           return;
         }
         const { query, type } = event;
-        const queryHash = hashFn(queryKey);
-        if (type === "queryRemoved" && query.queryHash === queryHash) {
+        if (type === "queryRemoved") {
           queryCacheUnsubscribe(subscriptionHash);
         }
-        const isObserverEvent = type === "observerAdded" || type === "observerRemoved";
-        if (isObserverEvent && query.queryHash === queryHash) {
+        if (type === "observerAdded" || type === "observerRemoved") {
           const observersCount = query.getObserversCount();
           if (observersCount === 0) {
             firestoreUnsubscribe(subscriptionHash);


### PR DESCRIPTION
Fixes https://github.com/invertase/react-query-firebase/issues/25#issuecomment-1179769240

React-query-firebase was managing it's own observerCount, but it was incorrect. React-query already does this and is was correct.

When there are no observers firestore is unsubscribed. If there are observers it is added again.

Also improved the readability of the code a bit by using more variables / helper functions.

Verified it is working in my application that was having issues.

I had some trouble running the tests.