### PR TITLE
docs: Fix "Explcit" Typo to "Explicit"

### DIFF
--- a/docs/firestore/typescript.mdx
+++ b/docs/firestore/typescript.mdx
@@ -17,7 +17,7 @@ Firestore is a [`QuerySnapshot`](https://firebase.google.com/docs/reference/js/f
 For a type safe application, this is dangerous. There are 2 ways to ensure your data
 is returned type safe, either explicilty or inferred:
 
-### Explcit types
+### Explicit types
 
 Provide the type declaration to the hooks directly:
 


### PR DESCRIPTION
This is a simple fix related to issue #64.