### PR TITLE
Fix vitest aliases configuration

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,13 @@
 import { defineConfig } from "vitest/config";
+import path from "path";
 
 export default defineConfig({
   test: {
     coverage: {
       provider: "istanbul",
+    },
+    alias: {
+      "~/testing-utils": path.resolve(__dirname, "./vitest/utils"),
     },
   },
 });


### PR DESCRIPTION
Tests currently fail due to vitest failing to resolve the path of `~/testing-util`. Vitest seems not to automatically know how to resolve the alias. This PR introduces an `alias` key to the vitest config so as to explicitly configure vitest to resolve the path to the alias.
<img width="496" alt="image" src="https://github.com/user-attachments/assets/7d02ed64-24bf-4f4c-89fd-99cf9bb286ae">
