### PR TITLE
rename and add tests to useDocumentQuery

### DIFF
--- a/packages/react/src/firestore/index.ts
+++ b/packages/react/src/firestore/index.ts
@@ -1,1 +1,1 @@
-export { useFirestoreDocument } from "./useFirestoreDocument";
+export { useDocumentQuery } from "./useDocumentQuery";

--- a/packages/react/src/firestore/useDocumentQuery.test.tsx
+++ b/packages/react/src/firestore/useDocumentQuery.test.tsx
@@ -1,6 +1,6 @@
 import React, { type ReactNode } from "react";
 import { describe, expect, test, beforeEach } from "vitest";
-import { useFirestoreDocument } from "./useFirestoreDocument";
+import { useDocumentQuery } from "./useDocumentQuery";
 import { renderHook, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { doc, setDoc } from "firebase/firestore";
@@ -23,13 +23,13 @@ const wrapper = ({ children }: { children: ReactNode }) => (
   <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
 );
 
-describe("useFirestoreDocument", () => {
+describe("useDocumentQuery", () => {
   beforeEach(async () => {
     await wipeFirestore();
   });
 
   test("it works", async () => {
-    const ref = doc(firestore, "tests", "useFirestoreDocument");
+    const ref = doc(firestore, "tests", "useDocumentQuery");
 
     // Set some data
     await setDoc(ref, { foo: "bar" });
@@ -37,7 +37,7 @@ describe("useFirestoreDocument", () => {
     // Test the hook
     const { result } = renderHook(
       () =>
-        useFirestoreDocument(ref, {
+        useDocumentQuery(ref, {
           queryKey: ["some", "doc"],
         }),
       { wrapper }
@@ -65,7 +65,7 @@ describe("useFirestoreDocument", () => {
     //test the hook
     const { result } = renderHook(
       () =>
-        useFirestoreDocument(ref, {
+        useDocumentQuery(ref, {
           queryKey: ["server", "doc"],
           firestore: { source: "server" },
         }),
@@ -88,7 +88,7 @@ describe("useFirestoreDocument", () => {
 
     const { result } = renderHook(
       () =>
-        useFirestoreDocument(ref, {
+        useDocumentQuery(ref, {
           queryKey: ["restricted", "doc"],
         }),
       { wrapper }
@@ -108,7 +108,7 @@ describe("useFirestoreDocument", () => {
 
     const { result } = renderHook(
       () =>
-        useFirestoreDocument(ref, {
+        useDocumentQuery(ref, {
           queryKey: ["pending", "state"],
         }),
       { wrapper }
@@ -134,7 +134,7 @@ describe("useFirestoreDocument", () => {
 
     const { result } = renderHook(
       () =>
-        useFirestoreDocument(ref, {
+        useDocumentQuery(ref, {
           queryKey: ["typed", "doc"],
         }),
       { wrapper }

--- a/packages/react/src/firestore/useDocumentQuery.ts
+++ b/packages/react/src/firestore/useDocumentQuery.ts
@@ -18,7 +18,7 @@ type FirestoreUseQueryOptions<TData = unknown, TError = Error> = Omit<
   };
 };
 
-export function useFirestoreDocument<
+export function useDocumentQuery<
   FromFirestore extends DocumentData = DocumentData,
   ToFirestore extends DocumentData = DocumentData
 >(
@@ -29,7 +29,7 @@ export function useFirestoreDocument<
   >
 ) {
   const { firestore, ...queryOptions } = options;
-  
+
   return useQuery<DocumentSnapshot<FromFirestore, ToFirestore>, FirestoreError>(
     {
       ...queryOptions,

--- a/packages/react/src/firestore/useFirestoreDocument.test.tsx
+++ b/packages/react/src/firestore/useFirestoreDocument.test.tsx
@@ -97,7 +97,7 @@ describe("useFirestoreDocument", () => {
     expect(result.current.error).toBeDefined();
   });
 
-  test("returns pending state initally", async () => {
+  test("returns pending state initially", async () => {
     const ref = doc(firestore, "tests", "pendingState");
 
     setDoc(ref, { foo: "pending" });

--- a/packages/react/src/firestore/useFirestoreDocument.test.tsx
+++ b/packages/react/src/firestore/useFirestoreDocument.test.tsx
@@ -122,4 +122,27 @@ describe("useFirestoreDocument", () => {
     expect(snapshot?.exists()).toBe(true);
     expect(snapshot?.data()?.foo).toBe("pending");
   });
+
+  test("returns correct data type", async () => {
+    const ref = doc(firestore, "tests", "typedDoc");
+
+    setDoc(ref, { foo: "bar", num: 23 } as { foo: string; num: number });
+
+    const { result } = renderHook(
+      () =>
+        useFirestoreDocument(ref, {
+          queryKey: ["typed", "doc"],
+        }),
+      { wrapper }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    const snapshot = result.current.data;
+    expect(snapshot?.exists()).toBe(true);
+    expect(snapshot?.data()?.foo).toBe("bar");
+    expect(snapshot?.data()?.num).toBe(23);
+  });
 });

--- a/packages/react/src/firestore/useFirestoreDocument.test.tsx
+++ b/packages/react/src/firestore/useFirestoreDocument.test.tsx
@@ -96,4 +96,30 @@ describe("useFirestoreDocument", () => {
 
     expect(result.current.error).toBeDefined();
   });
+
+  test("returns pending state initally", async () => {
+    const ref = doc(firestore, "tests", "pendingState");
+
+    setDoc(ref, { foo: "pending" });
+
+    const { result } = renderHook(
+      () =>
+        useFirestoreDocument(ref, {
+          queryKey: ["pending", "state"],
+        }),
+      { wrapper }
+    );
+
+    // initially isPending should be true
+    expect(result.current.isPending).toBe(true);
+
+    // wait for the query to finish, and should have isSuccess true
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    const snapshot = result.current.data;
+    expect(snapshot?.exists()).toBe(true);
+    expect(snapshot?.data()?.foo).toBe("pending");
+  });
 });

--- a/packages/react/src/firestore/useFirestoreDocument.test.tsx
+++ b/packages/react/src/firestore/useFirestoreDocument.test.tsx
@@ -51,4 +51,31 @@ describe("useFirestoreDocument", () => {
     expect(snapshot.exists()).toBe(true);
     expect(snapshot.data()?.foo).toBe("bar");
   });
+
+  test("fetches document from server source", async () => {
+    const ref = doc(firestore, "tests", "serverSource");
+
+    // set data
+    await setDoc(ref, { foo: "fromServer" });
+
+    //test the hook
+    const { result } = renderHook(
+      () =>
+        useFirestoreDocument(ref, {
+          queryKey: ["server", "doc"],
+          firestore: { source: "server" },
+        }),
+      { wrapper }
+    );
+
+    // await the query
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    // snapshot should exist, data should be fetched from the server and should contain the correct data
+    const snapshot = result.current.data;
+    expect(snapshot?.exists()).toBe(true);
+    expect(snapshot?.data()?.foo).toBe("fromServer");
+  });
 });

--- a/packages/react/src/firestore/useFirestoreDocument.test.tsx
+++ b/packages/react/src/firestore/useFirestoreDocument.test.tsx
@@ -78,4 +78,22 @@ describe("useFirestoreDocument", () => {
     expect(snapshot?.exists()).toBe(true);
     expect(snapshot?.data()?.foo).toBe("fromServer");
   });
+
+  test("handles fetch errors", async () => {
+    const ref = doc(firestore, "nonExistentCollection", "nonExistentDoc");
+
+    const { result } = renderHook(
+      () =>
+        useFirestoreDocument(ref, {
+          queryKey: ["error", "doc"],
+        }),
+      { wrapper }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error).toBeDefined();
+  });
 });

--- a/vitest/utils.ts
+++ b/vitest/utils.ts
@@ -1,9 +1,10 @@
-import { type FirebaseApp, initializeApp } from "firebase/app";
+import { type FirebaseApp, FirebaseError, initializeApp } from "firebase/app";
 import {
   getFirestore,
   connectFirestoreEmulator,
   type Firestore,
 } from "firebase/firestore";
+import { expect } from "vitest";
 
 const firebaseTestingOptions = {
   projectId: "test-project",
@@ -32,4 +33,16 @@ async function wipeFirestore() {
   }
 }
 
-export { firestore, wipeFirestore };
+function expectFirestoreError(error: unknown, expectedCode: string) {
+  if (error instanceof FirebaseError) {
+    expect(error).toBeDefined();
+    expect(error.code).toBeDefined();
+    expect(error.code).toBe(expectedCode);
+  } else {
+    throw new Error(
+      "Expected a Firestore error, but received a different type."
+    );
+  }
+}
+
+export { firestore, wipeFirestore, expectFirestoreError };


### PR DESCRIPTION
This PR tests the `useDocumentQuery` hook for the following assertions;
- fetches document from server source
- handles fetch errors
- returns pending state initially
- returns correct data type



